### PR TITLE
adhere to padded-blocks

### DIFF
--- a/test/log.js
+++ b/test/log.js
@@ -16,7 +16,6 @@ describe('Full HAR', function () {
 
       done()
     })
-
   })
 
   it('should fail with empty array', function (done) {

--- a/test/request.js
+++ b/test/request.js
@@ -16,7 +16,6 @@ describe('Request Only', function () {
 
       done()
     })
-
   })
 
   it('should fail with empty array', function (done) {

--- a/test/response.js
+++ b/test/response.js
@@ -16,7 +16,6 @@ describe('Response Only', function () {
 
       done()
     })
-
   })
 
   it('should fail with empty array', function (done) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.