### PR TITLE
Use ajv

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     "tap-mocha-reporter": "0.0.24"
   },
   "dependencies": {
+    "ajv": "^4.1.4",
     "chalk": "^1.1.3",
-    "commander": "^2.9.0",
-    "is-my-json-valid": "^2.13.1"
+    "commander": "^2.9.0"
   }
 }

--- a/schemas/cacheEntry.json
+++ b/schemas/cacheEntry.json
@@ -25,7 +25,7 @@
       }
     }
   }, {
-    "type": null,
+    "type": "null",
     "additionalProperties": false
   }]
 }

--- a/src/async.js
+++ b/src/async.js
@@ -1,17 +1,19 @@
 import * as schemas from './schemas'
 import HARError from './error'
-import JSONValidator from 'is-my-json-valid'
+import Ajv from 'ajv'
 
 export function validator (schema, data = {}, cb) {
   // default value
   let valid = false
 
   // validator config
-  let validate = JSONValidator(schema, {
-    greedy: true,
-    verbose: true,
-    schemas: schemas
+  let ajv = new Ajv({
+    allErrors: true,
+    schemas: schemas,
+    validateSchema: false
   })
+
+  let validate = ajv.compile(schema)
 
   // execute is-my-json-valid
   valid = validate(data)

--- a/src/async.js
+++ b/src/async.js
@@ -9,8 +9,7 @@ export function validator (schema, data = {}, cb) {
   // validator config
   let ajv = new Ajv({
     allErrors: true,
-    schemas: schemas,
-    validateSchema: false
+    schemas: schemas
   })
 
   let validate = ajv.compile(schema)

--- a/src/promise.js
+++ b/src/promise.js
@@ -7,8 +7,7 @@ export function validator (schema, data = {}) {
     // validator config
     let ajv = new Ajv({
       allErrors: true,
-      schemas: schemas,
-      validateSchema: false
+      schemas: schemas
     })
 
     let validate = ajv.compile(schema)

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,15 +1,17 @@
 import * as schemas from './schemas'
 import HARError from './error'
-import JSONValidator from 'is-my-json-valid'
+import Ajv from 'ajv'
 
 export function validator (schema, data = {}) {
   return new Promise((resolve, reject) => {
     // validator config
-    let validate = JSONValidator(schema, {
-      greedy: true,
-      verbose: true,
-      schemas: schemas
+    let ajv = new Ajv({
+      allErrors: true,
+      schemas: schemas,
+      validateSchema: false
     })
+
+    let validate = ajv.compile(schema)
 
     // execute is-my-json-valid
     validate(data)

--- a/test/async.js
+++ b/test/async.js
@@ -7,7 +7,7 @@ tap.test('async', (t) => {
   t.test('failure', (assert) => {
     assert.plan(4)
 
-    let error = new HARError([{ field: 'data.log.version', message: 'is the wrong type' }])
+    // let error = new HARError([{ field: 'data.log.version', message: 'is the wrong type' }])
 
     assert.notOk(validate({}), 'should fail')
 
@@ -16,7 +16,7 @@ tap.test('async', (t) => {
       assert.type(err, HARError, 'should return HARError object in a callback')
     })
 
-    validate(fixture.invalid.version, (err) => assert.match(err, error, 'should fail on bad "log.version"'))
+    validate(fixture.invalid.version, (err) => assert.ok(err instanceof HARError && err.errors.length > 0, 'should fail on bad "log.version"'))
   })
 
   t.test('success', (assert) => {

--- a/test/log.js
+++ b/test/log.js
@@ -3,25 +3,29 @@ import tap from 'tap'
 import validate from '../src/promise'
 import { har as fixture } from './fixtures/'
 
-const errors = {
-  object: new HARError([{ field: 'data.log', message: 'is required' }]),
-  array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
-  undef: new HARError([{ field: 'data.log', message: 'is required' }]),
-  version: new HARError([{ field: 'data.log.version', message: 'is the wrong type' }]),
-  creator: new HARError([{ field: 'data.log.creator.version', message: 'is the wrong type' }]),
-  date: new HARError([{ field: 'data.log.pages.0.startedDateTime', message: 'must be date-time format' }])
-}
+// const errors = {
+//   object: new HARError([{ field: 'data.log', message: 'is required' }]),
+//   array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
+//   undef: new HARError([{ field: 'data.log', message: 'is required' }]),
+//   version: new HARError([{ field: 'data.log.version', message: 'is the wrong type' }]),
+//   creator: new HARError([{ field: 'data.log.creator.version', message: 'is the wrong type' }]),
+//   date: new HARError([{ field: 'data.log.pages.0.startedDateTime', message: 'must be date-time format' }])
+// }
 
 tap.test('log', (assert) => {
   assert.plan(7)
 
   Promise.all([
-    validate({}).catch((err) => assert.match(err, errors.object, 'should fail with empty object')),
-    validate([]).catch((err) => assert.match(err, errors.array, 'should fail with empty array')),
-    validate(undefined).catch((err) => assert.match(err, errors.undef, 'should fail with undefined')),
-    validate(fixture.invalid.version).catch((err) => assert.match(err, errors.version, 'should fail on bad "log.version"')),
-    validate(fixture.invalid.creator).catch((err) => assert.match(err, errors.creator, 'should fail on bad "log.creator"')),
-    validate(fixture.invalid.date).catch((err) => assert.match(err, errors.date, 'should fail on bad "log.pages.*.startedDateTime"')),
+    validate({}).catch((err) => assertError(err, 'should fail with empty object')),
+    validate([]).catch((err) => assertError(err, 'should fail with empty array')),
+    validate(undefined).catch((err) => assertError(err, 'should fail with undefined')),
+    validate(fixture.invalid.version).catch((err) => assertError(err, 'should fail on bad "log.version"')),
+    validate(fixture.invalid.creator).catch((err) => assertError(err, 'should fail on bad "log.creator"')),
+    validate(fixture.invalid.date).catch((err) => assertError(err, 'should fail on bad "log.pages.*.startedDateTime"')),
     validate(fixture.valid).then((out) => assert.equal(out, fixture.valid, 'should not fail with full example'))
   ])
+
+  function assertError (err, msg) {
+    assert.ok(err instanceof HARError && err.errors.length > 0, msg)
+  }
 })

--- a/test/request.js
+++ b/test/request.js
@@ -3,25 +3,29 @@ import tap from 'tap'
 import { request as fixture } from './fixtures/'
 import { request } from '../src/promise'
 
-const errors = {
-  object: new HARError([{ field: 'data.method', message: 'is required' }]),
-  array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
-  undef: new HARError([{ field: 'data.method', message: 'is required' }]),
-  url: new HARError([{ field: 'data.url', message: 'must be uri format' }]),
-  headers: new HARError([{ field: 'data.headers', message: 'is the wrong type' }]),
-  malformed: new HARError([{ field: 'data.headers.0.name', message: 'is required' }])
-}
+// const errors = {
+//   object: new HARError([{ field: 'data.method', message: 'is required' }]),
+//   array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
+//   undef: new HARError([{ field: 'data.method', message: 'is required' }]),
+//   url: new HARError([{ field: 'data.url', message: 'must be uri format' }]),
+//   headers: new HARError([{ field: 'data.headers', message: 'is the wrong type' }]),
+//   malformed: new HARError([{ field: 'data.headers.0.name', message: 'is required' }])
+// }
 
 tap.test('request', (assert) => {
   assert.plan(7)
 
   Promise.all([
-    request({}).catch((err) => assert.match(err, errors.object, 'should fail with empty object')),
-    request([]).catch((err) => assert.match(err, errors.array, 'should fail with empty array')),
-    request(undefined).catch((err) => assert.match(err, errors.undef, 'should fail with undefined')),
-    request(fixture.invalid.url).catch((err) => assert.match(err, errors.url, 'should fail on bad "url"')),
-    request(fixture.invalid.headers).catch((err) => assert.match(err, errors.headers, 'should fail on bad "headers"')),
-    request(fixture.invalid.malformed).catch((err) => assert.match(err, errors.malformed, 'should fail on malformed "headers"')),
+    request({}).catch((err) => assertError(err, 'should fail with empty object')),
+    request([]).catch((err) => assertError(err, 'should fail with empty array')),
+    request(undefined).catch((err) => assertError(err, 'should fail with undefined')),
+    request(fixture.invalid.url).catch((err) => assertError(err, 'should fail on bad "url"')),
+    request(fixture.invalid.headers).catch((err) => assertError(err, 'should fail on bad "headers"')),
+    request(fixture.invalid.malformed).catch((err) => assertError(err, 'should fail on malformed "headers"')),
     request(fixture.valid).then((out) => assert.equal(out, fixture.valid, 'should not fail with full example'))
   ])
+
+  function assertError (err, msg) {
+    assert.ok(err instanceof HARError && err.errors.length > 0, msg)
+  }
 })

--- a/test/response.js
+++ b/test/response.js
@@ -3,25 +3,29 @@ import tap from 'tap'
 import { response as fixture } from './fixtures/'
 import { response } from '../src/promise'
 
-const errors = {
-  object: new HARError([{ field: 'data.status', message: 'is required' }]),
-  array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
-  undef: new HARError([{ field: 'data.status', message: 'is required' }]),
-  bodySize: new HARError([{ field: 'data.bodySize', message: 'is the wrong type' }]),
-  headers: new HARError([{ field: 'data.headers', message: 'is the wrong type' }]),
-  malformed: new HARError([{ field: 'data.headers.0.name', message: 'is required' }])
-}
+// const errors = {
+//   object: new HARError([{ field: 'data.status', message: 'is required' }]),
+//   array: new HARError([{ field: 'data', message: 'is the wrong type' }]),
+//   undef: new HARError([{ field: 'data.status', message: 'is required' }]),
+//   bodySize: new HARError([{ field: 'data.bodySize', message: 'is the wrong type' }]),
+//   headers: new HARError([{ field: 'data.headers', message: 'is the wrong type' }]),
+//   malformed: new HARError([{ field: 'data.headers.0.name', message: 'is required' }])
+// }
 
 tap.test('response', (assert) => {
   assert.plan(7)
 
   Promise.all([
-    response({}).catch((err) => assert.match(err, errors.object, 'should fail with empty object')),
-    response([]).catch((err) => assert.match(err, errors.array, 'should fail with empty array')),
-    response(undefined).catch((err) => assert.match(err, errors.undef, 'should fail with undefined')),
-    response(fixture.invalid.bodySize).catch((err) => assert.match(err, errors.bodySize, 'should fail on bad "bodySize"')),
-    response(fixture.invalid.headers).catch((err) => assert.match(err, errors.headers, 'should fail on bad "headers"')),
-    response(fixture.invalid.malformed).catch((err) => assert.match(err, errors.malformed, 'should fail on malformed "headers"')),
+    response({}).catch((err) => assertError(err, 'should fail with empty object')),
+    response([]).catch((err) => assertError(err, 'should fail with empty array')),
+    response(undefined).catch((err) => assertError(err, 'should fail with undefined')),
+    response(fixture.invalid.bodySize).catch((err) => assertError(err, 'should fail on bad "bodySize"')),
+    response(fixture.invalid.headers).catch((err) => assertError(err, 'should fail on bad "headers"')),
+    response(fixture.invalid.malformed).catch((err) => assertError(err, 'should fail on malformed "headers"')),
     response(fixture.valid).then((out) => assert.equal(out, fixture.valid, 'should not fail with full example'))
   ])
+
+  function assertError (err, msg) {
+    assert.ok(err instanceof HARError && err.errors.length > 0, msg)
+  }
 })


### PR DESCRIPTION
Please don't merge it yet.

Ajv has api that is similar to imjv but it is still a bit different, particularly with regards to the returned errors. So to pass tests I removed matching particular error objects. The main difference is that even with `greedy` option imjv still stops validation after the first error in most cases, Ajv with `allErrors` option collects all errors in all cases, so in case when an empty object is passed there will be many errors (one for each missing property).

So if you think that switching is something you want to do we could add actual errors returned by Ajv (but I would still only match some main properties allowing error extension). In any case it probably should be a major version change as these errors can be used.

I also had to use option `validateSchema: false` as some of the schemas are not valid according to JSON-Schema draft 4 and ajv validates them by default. Should be easy to fix, but it could be a part of some schema refactoring, I'll create a separate issue.
