### PR TITLE
re-use validator instance and compiled schema functions

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -1,18 +1,21 @@
 import * as schemas from 'har-schema'
 import Ajv from 'ajv'
 import HARError from './error'
+var ajv
 
 export function validator (schema, data = {}, cb) {
   // default value
   let valid = false
 
   // validator config
-  let ajv = new Ajv({
+  ajv = ajv || new Ajv({
     allErrors: true,
     schemas: schemas
   })
 
-  let validate = ajv.compile(schema)
+  let validate = typeof schema === 'string'
+                  ? ajv.getSchema(schema)
+                  : ajv.compile(schema)
 
   // execute validation
   valid = validate(data)
@@ -26,73 +29,73 @@ export function validator (schema, data = {}, cb) {
 }
 
 export function afterRequest (data, cb) {
-  return validator(schemas.afterRequest, data, cb)
+  return validator('afterRequest.json', data, cb)
 }
 
 export function beforeRequest (data, cb) {
-  return validator(schemas.beforeRequest, data, cb)
+  return validator('beforeRequest.json', data, cb)
 }
 
 export function browser (data, cb) {
-  return validator(schemas.browser, data, cb)
+  return validator('browser.json', data, cb)
 }
 
 export function cache (data, cb) {
-  return validator(schemas.cache, data, cb)
+  return validator('cache.json', data, cb)
 }
 
 export function content (data, cb) {
-  return validator(schemas.content, data, cb)
+  return validator('content.json', data, cb)
 }
 
 export function cookie (data, cb) {
-  return validator(schemas.cookie, data, cb)
+  return validator('cookie.json', data, cb)
 }
 
 export function creator (data, cb) {
-  return validator(schemas.creator, data, cb)
+  return validator('creator.json', data, cb)
 }
 
 export function entry (data, cb) {
-  return validator(schemas.entry, data, cb)
+  return validator('entry.json', data, cb)
 }
 
 export function har (data, cb) {
-  return validator(schemas.har, data, cb)
+  return validator('har.json', data, cb)
 }
 
 export function header (data, cb) {
-  return validator(schemas.header, data, cb)
+  return validator('header.json', data, cb)
 }
 
 export function log (data, cb) {
-  return validator(schemas.log, data, cb)
+  return validator('log.json', data, cb)
 }
 
 export function page (data, cb) {
-  return validator(schemas.page, data, cb)
+  return validator('page.json', data, cb)
 }
 
 export function pageTimings (data, cb) {
-  return validator(schemas.pageTimings, data, cb)
+  return validator('pageTimings.json', data, cb)
 }
 
 export function postData (data, cb) {
-  return validator(schemas.postData, data, cb)
+  return validator('postData.json', data, cb)
 }
 
 export function query (data, cb) {
-  return validator(schemas.query, data, cb)
+  return validator('query.json', data, cb)
 }
 
 export function request (data, cb) {
-  return validator(schemas.request, data, cb)
+  return validator('request.json', data, cb)
 }
 
 export function response (data, cb) {
-  return validator(schemas.response, data, cb)
+  return validator('response.json', data, cb)
 }
 
 export function timings (data, cb) {
-  return validator(schemas.timings, data, cb)
+  return validator('timings.json', data, cb)
 }

--- a/src/promise.js
+++ b/src/promise.js
@@ -1,16 +1,19 @@
 import * as schemas from 'har-schema'
 import Ajv from 'ajv'
 import HARError from './error'
+var ajv
 
 export function validator (schema, data = {}) {
   return new Promise((resolve, reject) => {
     // validator config
-    let ajv = new Ajv({
+    ajv = ajv || new Ajv({
       allErrors: true,
       schemas: schemas
     })
 
-    let validate = ajv.compile(schema)
+    let validate = typeof schema === 'string'
+                    ? ajv.getSchema(schema)
+                    : ajv.compile(schema)
 
     // execute validation
     validate(data)
@@ -20,73 +23,73 @@ export function validator (schema, data = {}) {
 }
 
 export function afterRequest (data) {
-  return validator(schemas.afterRequest, data)
+  return validator('afterRequest.json', data)
 }
 
 export function beforeRequest (data) {
-  return validator(schemas.beforeRequest, data)
+  return validator('beforeRequest.json', data)
 }
 
 export function browser (data) {
-  return validator(schemas.browser, data)
+  return validator('browser.json', data)
 }
 
 export function cache (data) {
-  return validator(schemas.cache, data)
+  return validator('cache.json', data)
 }
 
 export function content (data) {
-  return validator(schemas.content, data)
+  return validator('content.json', data)
 }
 
 export function cookie (data) {
-  return validator(schemas.cookie, data)
+  return validator('cookie.json', data)
 }
 
 export function creator (data) {
-  return validator(schemas.creator, data)
+  return validator('creator.json', data)
 }
 
 export function entry (data) {
-  return validator(schemas.entry, data)
+  return validator('entry.json', data)
 }
 
 export function har (data) {
-  return validator(schemas.har, data)
+  return validator('har.json', data)
 }
 
 export function header (data) {
-  return validator(schemas.header, data)
+  return validator('header.json', data)
 }
 
 export function log (data) {
-  return validator(schemas.log, data)
+  return validator('log.json', data)
 }
 
 export function page (data) {
-  return validator(schemas.page, data)
+  return validator('page.json', data)
 }
 
 export function pageTimings (data) {
-  return validator(schemas.pageTimings, data)
+  return validator('pageTimings.json', data)
 }
 
 export function postData (data) {
-  return validator(schemas.postData, data)
+  return validator('postData.json', data)
 }
 
 export function query (data) {
-  return validator(schemas.query, data)
+  return validator('query.json', data)
 }
 
 export function request (data) {
-  return validator(schemas.request, data)
+  return validator('request.json', data)
 }
 
 export function response (data) {
-  return validator(schemas.response, data)
+  return validator('response.json', data)
 }
 
 export function timings (data) {
-  return validator(schemas.timings, data)
+  return validator('timings.json', data)
 }


### PR DESCRIPTION
Creating Ajv and compiling schema every time seems wasteful, they can be re-used.
The change is backward compatible.
It still does not create the instance until the first call.