### PR TITLE
fix: create Ajv instance lazily, that should fix request/request#2572

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -2,13 +2,15 @@ import * as schemas from 'har-schema'
 import Ajv from 'ajv'
 import HARError from './error'
 
-// validator config
-let ajv = new Ajv({
-  allErrors: true,
-  schemas: schemas
-})
+let ajv
 
 export function validate (name, data = {}, next) {
+  // validator config
+  ajv = ajv || new Ajv({
+    allErrors: true,
+    schemas: schemas
+  })
+
   let validate = ajv.getSchema(name + '.json')
 
   let valid = validate(data)

--- a/src/promise.js
+++ b/src/promise.js
@@ -2,13 +2,15 @@ import * as schemas from 'har-schema'
 import Ajv from 'ajv'
 import HARError from './error'
 
-// validator config
-let ajv = new Ajv({
-  allErrors: true,
-  schemas: schemas
-})
+let ajv
 
 export function validate (name, data = {}) {
+  // validator config
+  ajv = ajv || new Ajv({
+    allErrors: true,
+    schemas: schemas
+  })
+
   let validate = ajv.getSchema(name + '.json')
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
@ahmadnassri previously validator was used lazily, only when har-validator is used in request. Now it is used when har-validator is required. This issue would exist with all compiling (=fast) validators, not just with Ajv.

Once this PR is merged and published to npm the issue in the title will be resolved.